### PR TITLE
Digitalfun patch 1 remove tag prefix from metadata

### DIFF
--- a/obsidian-templates/new article.template.md
+++ b/obsidian-templates/new article.template.md
@@ -1,6 +1,6 @@
 ---
 author: name <email@mail.ch>
-tags: #note, #article
+tags: note, article
 ---
 
 # {{title}}

--- a/obsidian-templates/new meeting notes.template.md
+++ b/obsidian-templates/new meeting notes.template.md
@@ -1,15 +1,16 @@
 ---
 author: name <name@mail.ch>
-tags: #meeting-notes
+tags: meeting-notes
 ---
 
 # {{title}}
 
 _SHORT_DESCRIPTION_
 
-- Date: {{date:DD.MM.YYYY}}
+- Date: {{date:DD.MM.YYYY}}  
 - Attendees:  
-  * 
+  * PersonA
+  * PersonB
   
 - - - -  
     

--- a/obsidian-templates/new note.template.md
+++ b/obsidian-templates/new note.template.md
@@ -1,6 +1,6 @@
 ---
 author: name <name@mail.ch>
-tags: #note, #year-{{date:YYYY}}, #month-{{date:MM}}
+tags: note, year-{{date:YYYY}}, month-{{date:MM}}
 ---
 
 # {{title}}

--- a/obsidian-templates/new presentation.template.md
+++ b/obsidian-templates/new presentation.template.md
@@ -1,5 +1,5 @@
 ---
-tags: #presentation
+tags: presentation
 ---
 
 # <Presentation title>
@@ -10,6 +10,7 @@ tags: #presentation
 ---
 
 ## Fact 1
+
 - text
 - text
     - text

--- a/obsidian-templates/new zettelkasten note.template.md
+++ b/obsidian-templates/new zettelkasten note.template.md
@@ -1,6 +1,6 @@
 ---
 author: name <mail@mail.ch>
-tags: #note, #zettel, #zettelkasten, #year-{{date:YYYY}}, #month-{{date:MM}} 
+tags: note, zettel, zettelkasten, year-{{date:YYYY}}, month-{{date:MM}} 
 id: {{date:YYYYMMDDHHmm}}
 ---
 


### PR DESCRIPTION
- @metadata: remove "#" (tag prefix) from "tags" entires. They are assumed to be tags anyway and when using the prefix, Obsidian don't recognizes the tags correctly.